### PR TITLE
add option to not fail when payload is not found in issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,27 @@ with:
     issue_id: ${{ github.event.issue.number }}
     payload: yaml
 ```
+
+
+### Fail on missing payload
+By default the action will fail if the payload is not found in the issue. This behavior can be changed by setting the `fail_on_missing` option to `false`.
+
+```yaml
+name: Parse Issue Body
+uses: peter-murray/issue-body-parser-action@v2
+id: issue_body_parser
+with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    issue_id: ${{ github.event.issue.number }}
+    fail_on_missing: false
+```
+
+In this case, when the payload is not found in the issue, the payload value will be set to `NOT_FOUND`. You may want to skip other actions in your workflow if this is the case by using an `if` conditional as follows:
+```yaml
+name: Run something that uses the payload
+    if : steps.issue_body_parser_request.outputs.payload != 'NOT_FOUND'
+    id: run_something
+    env:
+        VERSION: ${{ fromJson(steps.issue_body_parser_request.outputs.payload).version }}
+    run: |
+    echo $VERSION

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,11 @@ inputs:
     required: true
     default: ""
 
+  fail_on_missing:
+    description: If true, the action will fail if the payload is not found in the Issue body
+    required: false
+    default: 'true'
+
 outputs:
   payload:
     description: The extracted payload data from the issue body for the issue id that was provided

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 7427:
+/***/ 3292:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28,7 +28,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(545);
+const utils_1 = __nccwpck_require__(3535);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 2896:
+/***/ 2362:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,12 +135,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(7427);
-const file_command_1 = __nccwpck_require__(7531);
-const utils_1 = __nccwpck_require__(545);
+const command_1 = __nccwpck_require__(3292);
+const file_command_1 = __nccwpck_require__(3814);
+const utils_1 = __nccwpck_require__(3535);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
-const oidc_utils_1 = __nccwpck_require__(9762);
+const oidc_utils_1 = __nccwpck_require__(230);
 /**
  * The code to exit an action
  */
@@ -418,17 +418,17 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(6783);
+var summary_1 = __nccwpck_require__(6536);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(6783);
+var summary_2 = __nccwpck_require__(6536);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(130);
+var path_utils_1 = __nccwpck_require__(242);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
@@ -436,7 +436,7 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 
 /***/ }),
 
-/***/ 7531:
+/***/ 3814:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -467,7 +467,7 @@ exports.issueCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(7147));
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(545);
+const utils_1 = __nccwpck_require__(3535);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -485,7 +485,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 9762:
+/***/ 230:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -501,9 +501,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(8737);
-const auth_1 = __nccwpck_require__(2103);
-const core_1 = __nccwpck_require__(2896);
+const http_client_1 = __nccwpck_require__(4101);
+const auth_1 = __nccwpck_require__(9433);
+const core_1 = __nccwpck_require__(2362);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -569,7 +569,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 130:
+/***/ 242:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -634,7 +634,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 6783:
+/***/ 6536:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -924,7 +924,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 545:
+/***/ 3535:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -971,7 +971,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 4680:
+/***/ 1026:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1024,7 +1024,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 1539:
+/***/ 5903:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1038,10 +1038,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Originally pulled from https://github.com/JasonEtco/actions-toolkit/blob/master/src/github.ts
-const graphql_1 = __nccwpck_require__(5456);
-const rest_1 = __nccwpck_require__(9629);
-const Context = __importStar(__nccwpck_require__(4680));
-const httpClient = __importStar(__nccwpck_require__(5991));
+const graphql_1 = __nccwpck_require__(3210);
+const rest_1 = __nccwpck_require__(111);
+const Context = __importStar(__nccwpck_require__(1026));
+const httpClient = __importStar(__nccwpck_require__(5755));
 // We need this in order to extend Octokit
 rest_1.Octokit.prototype = new rest_1.Octokit();
 exports.context = new Context.Context();
@@ -1139,7 +1139,7 @@ exports.GitHub = GitHub;
 
 /***/ }),
 
-/***/ 5991:
+/***/ 5755:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1147,7 +1147,7 @@ exports.GitHub = GitHub;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const http = __nccwpck_require__(3685);
 const https = __nccwpck_require__(5687);
-const pm = __nccwpck_require__(6354);
+const pm = __nccwpck_require__(1971);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1566,7 +1566,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(2192);
+                tunnel = __nccwpck_require__(538);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1684,7 +1684,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 6354:
+/***/ 1971:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1749,7 +1749,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 2103:
+/***/ 9433:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -1837,7 +1837,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 8737:
+/***/ 4101:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1875,8 +1875,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
 const http = __importStar(__nccwpck_require__(3685));
 const https = __importStar(__nccwpck_require__(5687));
-const pm = __importStar(__nccwpck_require__(8826));
-const tunnel = __importStar(__nccwpck_require__(2192));
+const pm = __importStar(__nccwpck_require__(7102));
+const tunnel = __importStar(__nccwpck_require__(538));
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -2449,7 +2449,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 8826:
+/***/ 7102:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2517,7 +2517,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 9760:
+/***/ 9173:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2580,7 +2580,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 5748:
+/***/ 1134:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2588,8 +2588,8 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __nccwpck_require__(7186);
-var universalUserAgent = __nccwpck_require__(7505);
+var isPlainObject = __nccwpck_require__(4370);
+var universalUserAgent = __nccwpck_require__(4667);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -2978,7 +2978,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 5456:
+/***/ 3210:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2986,8 +2986,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(6937);
-var universalUserAgent = __nccwpck_require__(7505);
+var request = __nccwpck_require__(5036);
+var universalUserAgent = __nccwpck_require__(4667);
 
 const VERSION = "4.8.0";
 
@@ -3104,7 +3104,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 1276:
+/***/ 1500:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3254,7 +3254,7 @@ exports.paginateRest = paginateRest;
 
 /***/ }),
 
-/***/ 2735:
+/***/ 2903:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3292,7 +3292,7 @@ exports.requestLog = requestLog;
 
 /***/ }),
 
-/***/ 2630:
+/***/ 376:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3300,7 +3300,7 @@ exports.requestLog = requestLog;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var deprecation = __nccwpck_require__(8333);
+var deprecation = __nccwpck_require__(6171);
 
 var endpointsByScope = {
   actions: {
@@ -16496,7 +16496,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 6635:
+/***/ 575:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16506,8 +16506,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(8333);
-var once = _interopDefault(__nccwpck_require__(5303));
+var deprecation = __nccwpck_require__(6171);
+var once = _interopDefault(__nccwpck_require__(6686));
 
 const logOnceCode = once(deprecation => console.warn(deprecation));
 const logOnceHeaders = once(deprecation => console.warn(deprecation));
@@ -16578,7 +16578,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 6937:
+/***/ 5036:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16588,11 +16588,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(5748);
-var universalUserAgent = __nccwpck_require__(7505);
-var isPlainObject = __nccwpck_require__(7186);
-var nodeFetch = _interopDefault(__nccwpck_require__(6415));
-var requestError = __nccwpck_require__(6635);
+var endpoint = __nccwpck_require__(1134);
+var universalUserAgent = __nccwpck_require__(4667);
+var isPlainObject = __nccwpck_require__(4370);
+var nodeFetch = _interopDefault(__nccwpck_require__(3422));
+var requestError = __nccwpck_require__(575);
 
 const VERSION = "5.6.3";
 
@@ -16763,25 +16763,25 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 9629:
+/***/ 111:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { requestLog } = __nccwpck_require__(2735);
+const { requestLog } = __nccwpck_require__(2903);
 const {
   restEndpointMethods
-} = __nccwpck_require__(2630);
+} = __nccwpck_require__(376);
 
-const Core = __nccwpck_require__(4848);
+const Core = __nccwpck_require__(8568);
 
 const CORE_PLUGINS = [
-  __nccwpck_require__(7985),
-  __nccwpck_require__(1541), // deprecated: remove in v17
+  __nccwpck_require__(6153),
+  __nccwpck_require__(3449), // deprecated: remove in v17
   requestLog,
-  __nccwpck_require__(7624),
+  __nccwpck_require__(4690),
   restEndpointMethods,
-  __nccwpck_require__(5665),
+  __nccwpck_require__(1306),
 
-  __nccwpck_require__(1747) // deprecated: remove in v17
+  __nccwpck_require__(7629) // deprecated: remove in v17
 ];
 
 const OctokitRest = Core.plugin(CORE_PLUGINS);
@@ -16813,15 +16813,15 @@ module.exports = Octokit;
 
 /***/ }),
 
-/***/ 7274:
+/***/ 4503:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = Octokit;
 
-const { request } = __nccwpck_require__(6937);
-const Hook = __nccwpck_require__(9252);
+const { request } = __nccwpck_require__(5036);
+const Hook = __nccwpck_require__(517);
 
-const parseClientOptions = __nccwpck_require__(5637);
+const parseClientOptions = __nccwpck_require__(8243);
 
 function Octokit(plugins, options) {
   options = options || {};
@@ -16849,23 +16849,23 @@ function Octokit(plugins, options) {
 
 /***/ }),
 
-/***/ 4848:
+/***/ 8568:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const factory = __nccwpck_require__(1599);
+const factory = __nccwpck_require__(9083);
 
 module.exports = factory();
 
 
 /***/ }),
 
-/***/ 1599:
+/***/ 9083:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = factory;
 
-const Octokit = __nccwpck_require__(7274);
-const registerPlugin = __nccwpck_require__(6858);
+const Octokit = __nccwpck_require__(4503);
+const registerPlugin = __nccwpck_require__(8412);
 
 function factory(plugins) {
   const Api = Octokit.bind(null, plugins || []);
@@ -16876,14 +16876,14 @@ function factory(plugins) {
 
 /***/ }),
 
-/***/ 5637:
+/***/ 8243:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = parseOptions;
 
-const { Deprecation } = __nccwpck_require__(8333);
-const { getUserAgent } = __nccwpck_require__(2351);
-const once = __nccwpck_require__(5303);
+const { Deprecation } = __nccwpck_require__(6171);
+const { getUserAgent } = __nccwpck_require__(5725);
+const once = __nccwpck_require__(6686);
 
 const pkg = __nccwpck_require__(1322);
 
@@ -16972,12 +16972,12 @@ function parseOptions(options, log, hook) {
 
 /***/ }),
 
-/***/ 6858:
+/***/ 8412:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = registerPlugin;
 
-const factory = __nccwpck_require__(1599);
+const factory = __nccwpck_require__(9083);
 
 function registerPlugin(plugins, pluginFunction) {
   return factory(
@@ -16988,7 +16988,7 @@ function registerPlugin(plugins, pluginFunction) {
 
 /***/ }),
 
-/***/ 9202:
+/***/ 162:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16998,8 +16998,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(8333);
-var once = _interopDefault(__nccwpck_require__(5303));
+var deprecation = __nccwpck_require__(6171);
+var once = _interopDefault(__nccwpck_require__(6686));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -17051,7 +17051,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 2351:
+/***/ 5725:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17061,7 +17061,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var osName = _interopDefault(__nccwpck_require__(746));
+var osName = _interopDefault(__nccwpck_require__(3069));
 
 function getUserAgent() {
   try {
@@ -17081,13 +17081,13 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 9385:
+/***/ 834:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticate;
 
-const { Deprecation } = __nccwpck_require__(8333);
-const once = __nccwpck_require__(5303);
+const { Deprecation } = __nccwpck_require__(6171);
+const once = __nccwpck_require__(6686);
 
 const deprecateAuthenticate = once((log, deprecation) => log.warn(deprecation));
 
@@ -17140,13 +17140,13 @@ function authenticate(state, options) {
 
 /***/ }),
 
-/***/ 2109:
+/***/ 3553:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationBeforeRequest;
 
-const btoa = __nccwpck_require__(1699);
-const uniq = __nccwpck_require__(2140);
+const btoa = __nccwpck_require__(3633);
+const uniq = __nccwpck_require__(3525);
 
 function authenticationBeforeRequest(state, options) {
   if (!state.auth.type) {
@@ -17190,19 +17190,19 @@ function authenticationBeforeRequest(state, options) {
 
 /***/ }),
 
-/***/ 1541:
+/***/ 3449:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationPlugin;
 
-const { Deprecation } = __nccwpck_require__(8333);
-const once = __nccwpck_require__(5303);
+const { Deprecation } = __nccwpck_require__(6171);
+const once = __nccwpck_require__(6686);
 
 const deprecateAuthenticate = once((log, deprecation) => log.warn(deprecation));
 
-const authenticate = __nccwpck_require__(9385);
-const beforeRequest = __nccwpck_require__(2109);
-const requestError = __nccwpck_require__(5232);
+const authenticate = __nccwpck_require__(834);
+const beforeRequest = __nccwpck_require__(3553);
+const requestError = __nccwpck_require__(2585);
 
 function authenticationPlugin(octokit, options) {
   if (options.auth) {
@@ -17228,12 +17228,12 @@ function authenticationPlugin(octokit, options) {
 
 /***/ }),
 
-/***/ 5232:
+/***/ 2585:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationRequestError;
 
-const { RequestError } = __nccwpck_require__(9202);
+const { RequestError } = __nccwpck_require__(162);
 
 function authenticationRequestError(state, error, options) {
   /* istanbul ignore next */
@@ -17290,14 +17290,14 @@ function authenticationRequestError(state, error, options) {
 
 /***/ }),
 
-/***/ 7827:
+/***/ 4841:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationBeforeRequest;
 
-const btoa = __nccwpck_require__(1699);
+const btoa = __nccwpck_require__(3633);
 
-const withAuthorizationPrefix = __nccwpck_require__(6368);
+const withAuthorizationPrefix = __nccwpck_require__(5269);
 
 function authenticationBeforeRequest(state, options) {
   if (typeof state.auth === "string") {
@@ -17350,19 +17350,19 @@ function authenticationBeforeRequest(state, options) {
 
 /***/ }),
 
-/***/ 7985:
+/***/ 6153:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationPlugin;
 
-const { createTokenAuth } = __nccwpck_require__(9760);
-const { Deprecation } = __nccwpck_require__(8333);
-const once = __nccwpck_require__(5303);
+const { createTokenAuth } = __nccwpck_require__(9173);
+const { Deprecation } = __nccwpck_require__(6171);
+const once = __nccwpck_require__(6686);
 
-const beforeRequest = __nccwpck_require__(7827);
-const requestError = __nccwpck_require__(490);
-const validate = __nccwpck_require__(6676);
-const withAuthorizationPrefix = __nccwpck_require__(6368);
+const beforeRequest = __nccwpck_require__(4841);
+const requestError = __nccwpck_require__(1435);
+const validate = __nccwpck_require__(3086);
+const withAuthorizationPrefix = __nccwpck_require__(5269);
 
 const deprecateAuthBasic = once((log, deprecation) => log.warn(deprecation));
 const deprecateAuthObject = once((log, deprecation) => log.warn(deprecation));
@@ -17433,12 +17433,12 @@ function authenticationPlugin(octokit, options) {
 
 /***/ }),
 
-/***/ 490:
+/***/ 1435:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationRequestError;
 
-const { RequestError } = __nccwpck_require__(9202);
+const { RequestError } = __nccwpck_require__(162);
 
 function authenticationRequestError(state, error, options) {
   if (!error.headers) throw error;
@@ -17501,7 +17501,7 @@ function authenticationRequestError(state, error, options) {
 
 /***/ }),
 
-/***/ 6676:
+/***/ 3086:
 /***/ ((module) => {
 
 module.exports = validateAuth;
@@ -17529,12 +17529,12 @@ function validateAuth(auth) {
 
 /***/ }),
 
-/***/ 6368:
+/***/ 5269:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = withAuthorizationPrefix;
 
-const atob = __nccwpck_require__(4222);
+const atob = __nccwpck_require__(5076);
 
 const REGEX_IS_BASIC_AUTH = /^[\w-]+:/;
 
@@ -17559,12 +17559,12 @@ function withAuthorizationPrefix(authorization) {
 
 /***/ }),
 
-/***/ 7624:
+/***/ 4690:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = paginatePlugin;
 
-const { paginateRest } = __nccwpck_require__(1276);
+const { paginateRest } = __nccwpck_require__(1500);
 
 function paginatePlugin(octokit) {
   Object.assign(octokit, paginateRest(octokit));
@@ -17573,12 +17573,12 @@ function paginatePlugin(octokit) {
 
 /***/ }),
 
-/***/ 5665:
+/***/ 1306:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = octokitValidate;
 
-const validate = __nccwpck_require__(6085);
+const validate = __nccwpck_require__(4354);
 
 function octokitValidate(octokit) {
   octokit.hook.before("request", validate.bind(null, octokit));
@@ -17587,7 +17587,7 @@ function octokitValidate(octokit) {
 
 /***/ }),
 
-/***/ 6085:
+/***/ 4354:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17595,9 +17595,9 @@ function octokitValidate(octokit) {
 
 module.exports = validate;
 
-const { RequestError } = __nccwpck_require__(9202);
-const get = __nccwpck_require__(5625);
-const set = __nccwpck_require__(6838);
+const { RequestError } = __nccwpck_require__(162);
+const get = __nccwpck_require__(1601);
+const set = __nccwpck_require__(213);
 
 function validate(octokit, options) {
   if (!options.request.validate) {
@@ -17746,7 +17746,7 @@ function validate(octokit, options) {
 
 /***/ }),
 
-/***/ 4222:
+/***/ 5076:
 /***/ ((module) => {
 
 module.exports = function atob(str) {
@@ -17756,12 +17756,12 @@ module.exports = function atob(str) {
 
 /***/ }),
 
-/***/ 9252:
+/***/ 517:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(4716)
-var addHook = __nccwpck_require__(3938)
-var removeHook = __nccwpck_require__(1094)
+var register = __nccwpck_require__(4681)
+var addHook = __nccwpck_require__(4289)
+var removeHook = __nccwpck_require__(979)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -17820,7 +17820,7 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 
-/***/ 3938:
+/***/ 4289:
 /***/ ((module) => {
 
 module.exports = addHook;
@@ -17873,7 +17873,7 @@ function addHook(state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 4716:
+/***/ 4681:
 /***/ ((module) => {
 
 module.exports = register;
@@ -17907,7 +17907,7 @@ function register(state, name, method, options) {
 
 /***/ }),
 
-/***/ 1094:
+/***/ 979:
 /***/ ((module) => {
 
 module.exports = removeHook;
@@ -17933,7 +17933,7 @@ function removeHook(state, name, method) {
 
 /***/ }),
 
-/***/ 1699:
+/***/ 3633:
 /***/ ((module) => {
 
 module.exports = function btoa(str) {
@@ -17943,15 +17943,15 @@ module.exports = function btoa(str) {
 
 /***/ }),
 
-/***/ 3167:
+/***/ 5935:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const cp = __nccwpck_require__(2081);
-const parse = __nccwpck_require__(6480);
-const enoent = __nccwpck_require__(6279);
+const parse = __nccwpck_require__(9387);
+const enoent = __nccwpck_require__(822);
 
 function spawn(command, args, options) {
     // Parse the arguments
@@ -17990,7 +17990,7 @@ module.exports._enoent = enoent;
 
 /***/ }),
 
-/***/ 6279:
+/***/ 822:
 /***/ ((module) => {
 
 "use strict";
@@ -18057,18 +18057,18 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6480:
+/***/ 9387:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const path = __nccwpck_require__(1017);
-const niceTry = __nccwpck_require__(119);
-const resolveCommand = __nccwpck_require__(8424);
-const escape = __nccwpck_require__(1428);
-const readShebang = __nccwpck_require__(9390);
-const semver = __nccwpck_require__(4338);
+const niceTry = __nccwpck_require__(6739);
+const resolveCommand = __nccwpck_require__(7760);
+const escape = __nccwpck_require__(9551);
+const readShebang = __nccwpck_require__(3280);
+const semver = __nccwpck_require__(2713);
 
 const isWin = process.platform === 'win32';
 const isExecutableRegExp = /\.(?:com|exe)$/i;
@@ -18190,7 +18190,7 @@ module.exports = parse;
 
 /***/ }),
 
-/***/ 1428:
+/***/ 9551:
 /***/ ((module) => {
 
 "use strict";
@@ -18243,14 +18243,14 @@ module.exports.argument = escapeArgument;
 
 /***/ }),
 
-/***/ 9390:
+/***/ 3280:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const fs = __nccwpck_require__(7147);
-const shebangCommand = __nccwpck_require__(5870);
+const shebangCommand = __nccwpck_require__(8349);
 
 function readShebang(command) {
     // Read the first 150 bytes from the file
@@ -18283,15 +18283,15 @@ module.exports = readShebang;
 
 /***/ }),
 
-/***/ 8424:
+/***/ 7760:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const path = __nccwpck_require__(1017);
-const which = __nccwpck_require__(8742);
-const pathKey = __nccwpck_require__(5932)();
+const which = __nccwpck_require__(2532);
+const pathKey = __nccwpck_require__(1507)();
 
 function resolveCommandAttempt(parsed, withoutPathExt) {
     const cwd = process.cwd();
@@ -18338,7 +18338,7 @@ module.exports = resolveCommand;
 
 /***/ }),
 
-/***/ 8333:
+/***/ 6171:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -18366,10 +18366,10 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 8246:
+/***/ 228:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var once = __nccwpck_require__(5303);
+var once = __nccwpck_require__(6686);
 
 var noop = function() {};
 
@@ -18467,22 +18467,22 @@ module.exports = eos;
 
 /***/ }),
 
-/***/ 5883:
+/***/ 8300:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const path = __nccwpck_require__(1017);
 const childProcess = __nccwpck_require__(2081);
-const crossSpawn = __nccwpck_require__(3167);
-const stripEof = __nccwpck_require__(8464);
-const npmRunPath = __nccwpck_require__(2745);
-const isStream = __nccwpck_require__(7557);
-const _getStream = __nccwpck_require__(5574);
-const pFinally = __nccwpck_require__(5935);
-const onExit = __nccwpck_require__(6456);
-const errname = __nccwpck_require__(5165);
-const stdio = __nccwpck_require__(301);
+const crossSpawn = __nccwpck_require__(5935);
+const stripEof = __nccwpck_require__(5292);
+const npmRunPath = __nccwpck_require__(1071);
+const isStream = __nccwpck_require__(7942);
+const _getStream = __nccwpck_require__(3391);
+const pFinally = __nccwpck_require__(6397);
+const onExit = __nccwpck_require__(4251);
+const errname = __nccwpck_require__(977);
+const stdio = __nccwpck_require__(5390);
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
@@ -18836,7 +18836,7 @@ module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, 
 
 /***/ }),
 
-/***/ 5165:
+/***/ 977:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18883,7 +18883,7 @@ function errname(uv, code) {
 
 /***/ }),
 
-/***/ 301:
+/***/ 5390:
 /***/ ((module) => {
 
 "use strict";
@@ -18932,7 +18932,7 @@ module.exports = opts => {
 
 /***/ }),
 
-/***/ 4969:
+/***/ 6204:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18991,13 +18991,13 @@ module.exports = options => {
 
 /***/ }),
 
-/***/ 5574:
+/***/ 3391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const pump = __nccwpck_require__(886);
-const bufferStream = __nccwpck_require__(4969);
+const pump = __nccwpck_require__(3509);
+const bufferStream = __nccwpck_require__(6204);
 
 class MaxBufferError extends Error {
 	constructor() {
@@ -19049,7 +19049,7 @@ module.exports.MaxBufferError = MaxBufferError;
 
 /***/ }),
 
-/***/ 7186:
+/***/ 4370:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -19095,7 +19095,7 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 7557:
+/***/ 7942:
 /***/ ((module) => {
 
 "use strict";
@@ -19124,15 +19124,15 @@ isStream.transform = function (stream) {
 
 /***/ }),
 
-/***/ 769:
+/***/ 2949:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var fs = __nccwpck_require__(7147)
 var core
 if (process.platform === 'win32' || global.TESTING_WINDOWS) {
-  core = __nccwpck_require__(2342)
+  core = __nccwpck_require__(7023)
 } else {
-  core = __nccwpck_require__(2813)
+  core = __nccwpck_require__(2985)
 }
 
 module.exports = isexe
@@ -19188,7 +19188,7 @@ function sync (path, options) {
 
 /***/ }),
 
-/***/ 2813:
+/***/ 2985:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = isexe
@@ -19236,7 +19236,7 @@ function checkMode (stat, options) {
 
 /***/ }),
 
-/***/ 2342:
+/***/ 7023:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = isexe
@@ -19285,7 +19285,7 @@ function sync (path, options) {
 
 /***/ }),
 
-/***/ 5625:
+/***/ 1601:
 /***/ ((module) => {
 
 /**
@@ -20223,7 +20223,7 @@ module.exports = get;
 
 /***/ }),
 
-/***/ 6838:
+/***/ 213:
 /***/ ((module) => {
 
 /**
@@ -21220,7 +21220,7 @@ module.exports = set;
 
 /***/ }),
 
-/***/ 2140:
+/***/ 3525:
 /***/ ((module) => {
 
 /**
@@ -22123,7 +22123,7 @@ module.exports = uniq;
 
 /***/ }),
 
-/***/ 3443:
+/***/ 3701:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22168,7 +22168,7 @@ module.exports["default"] = macosRelease;
 
 /***/ }),
 
-/***/ 119:
+/***/ 6739:
 /***/ ((module) => {
 
 "use strict";
@@ -22187,7 +22187,7 @@ module.exports = function(fn) {
 
 /***/ }),
 
-/***/ 6415:
+/***/ 3422:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22200,7 +22200,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var Stream = _interopDefault(__nccwpck_require__(2781));
 var http = _interopDefault(__nccwpck_require__(3685));
 var Url = _interopDefault(__nccwpck_require__(7310));
-var whatwgUrl = _interopDefault(__nccwpck_require__(3821));
+var whatwgUrl = _interopDefault(__nccwpck_require__(9941));
 var https = _interopDefault(__nccwpck_require__(5687));
 var zlib = _interopDefault(__nccwpck_require__(9796));
 
@@ -22353,7 +22353,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = (__nccwpck_require__(7106).convert);
+	convert = (__nccwpck_require__(4765).convert);
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -23892,13 +23892,13 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 2745:
+/***/ 1071:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const path = __nccwpck_require__(1017);
-const pathKey = __nccwpck_require__(5932);
+const pathKey = __nccwpck_require__(1507);
 
 module.exports = opts => {
 	opts = Object.assign({
@@ -23939,26 +23939,26 @@ module.exports.env = opts => {
 
 /***/ }),
 
-/***/ 1747:
+/***/ 7629:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = paginationMethodsPlugin
 
 function paginationMethodsPlugin (octokit) {
-  octokit.getFirstPage = (__nccwpck_require__(7003).bind)(null, octokit)
-  octokit.getLastPage = (__nccwpck_require__(2176).bind)(null, octokit)
-  octokit.getNextPage = (__nccwpck_require__(1444).bind)(null, octokit)
-  octokit.getPreviousPage = (__nccwpck_require__(4501).bind)(null, octokit)
-  octokit.hasFirstPage = __nccwpck_require__(8463)
-  octokit.hasLastPage = __nccwpck_require__(8881)
-  octokit.hasNextPage = __nccwpck_require__(5847)
-  octokit.hasPreviousPage = __nccwpck_require__(7056)
+  octokit.getFirstPage = (__nccwpck_require__(7036).bind)(null, octokit)
+  octokit.getLastPage = (__nccwpck_require__(5980).bind)(null, octokit)
+  octokit.getNextPage = (__nccwpck_require__(870).bind)(null, octokit)
+  octokit.getPreviousPage = (__nccwpck_require__(9002).bind)(null, octokit)
+  octokit.hasFirstPage = __nccwpck_require__(3750)
+  octokit.hasLastPage = __nccwpck_require__(217)
+  octokit.hasNextPage = __nccwpck_require__(5657)
+  octokit.hasPreviousPage = __nccwpck_require__(6024)
 }
 
 
 /***/ }),
 
-/***/ 1451:
+/***/ 9543:
 /***/ ((module) => {
 
 module.exports = deprecate
@@ -23977,12 +23977,12 @@ function deprecate (message) {
 
 /***/ }),
 
-/***/ 7003:
+/***/ 7036:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getFirstPage
 
-const getPage = __nccwpck_require__(7734)
+const getPage = __nccwpck_require__(4537)
 
 function getFirstPage (octokit, link, headers) {
   return getPage(octokit, link, 'first', headers)
@@ -23991,12 +23991,12 @@ function getFirstPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 2176:
+/***/ 5980:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getLastPage
 
-const getPage = __nccwpck_require__(7734)
+const getPage = __nccwpck_require__(4537)
 
 function getLastPage (octokit, link, headers) {
   return getPage(octokit, link, 'last', headers)
@@ -24005,12 +24005,12 @@ function getLastPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 1444:
+/***/ 870:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getNextPage
 
-const getPage = __nccwpck_require__(7734)
+const getPage = __nccwpck_require__(4537)
 
 function getNextPage (octokit, link, headers) {
   return getPage(octokit, link, 'next', headers)
@@ -24019,7 +24019,7 @@ function getNextPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 6854:
+/***/ 3416:
 /***/ ((module) => {
 
 module.exports = getPageLinks
@@ -24041,14 +24041,14 @@ function getPageLinks (link) {
 
 /***/ }),
 
-/***/ 7734:
+/***/ 4537:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getPage
 
-const deprecate = __nccwpck_require__(1451)
-const getPageLinks = __nccwpck_require__(6854)
-const HttpError = __nccwpck_require__(36)
+const deprecate = __nccwpck_require__(9543)
+const getPageLinks = __nccwpck_require__(3416)
+const HttpError = __nccwpck_require__(4115)
 
 function getPage (octokit, link, which, headers) {
   deprecate(`octokit.get${which.charAt(0).toUpperCase() + which.slice(1)}Page() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -24086,12 +24086,12 @@ function applyAcceptHeader (res, headers) {
 
 /***/ }),
 
-/***/ 4501:
+/***/ 9002:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getPreviousPage
 
-const getPage = __nccwpck_require__(7734)
+const getPage = __nccwpck_require__(4537)
 
 function getPreviousPage (octokit, link, headers) {
   return getPage(octokit, link, 'prev', headers)
@@ -24100,13 +24100,13 @@ function getPreviousPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 8463:
+/***/ 3750:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasFirstPage
 
-const deprecate = __nccwpck_require__(1451)
-const getPageLinks = __nccwpck_require__(6854)
+const deprecate = __nccwpck_require__(9543)
+const getPageLinks = __nccwpck_require__(3416)
 
 function hasFirstPage (link) {
   deprecate(`octokit.hasFirstPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -24116,13 +24116,13 @@ function hasFirstPage (link) {
 
 /***/ }),
 
-/***/ 8881:
+/***/ 217:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasLastPage
 
-const deprecate = __nccwpck_require__(1451)
-const getPageLinks = __nccwpck_require__(6854)
+const deprecate = __nccwpck_require__(9543)
+const getPageLinks = __nccwpck_require__(3416)
 
 function hasLastPage (link) {
   deprecate(`octokit.hasLastPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -24132,13 +24132,13 @@ function hasLastPage (link) {
 
 /***/ }),
 
-/***/ 5847:
+/***/ 5657:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasNextPage
 
-const deprecate = __nccwpck_require__(1451)
-const getPageLinks = __nccwpck_require__(6854)
+const deprecate = __nccwpck_require__(9543)
+const getPageLinks = __nccwpck_require__(3416)
 
 function hasNextPage (link) {
   deprecate(`octokit.hasNextPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -24148,13 +24148,13 @@ function hasNextPage (link) {
 
 /***/ }),
 
-/***/ 7056:
+/***/ 6024:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasPreviousPage
 
-const deprecate = __nccwpck_require__(1451)
-const getPageLinks = __nccwpck_require__(6854)
+const deprecate = __nccwpck_require__(9543)
+const getPageLinks = __nccwpck_require__(3416)
 
 function hasPreviousPage (link) {
   deprecate(`octokit.hasPreviousPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -24164,7 +24164,7 @@ function hasPreviousPage (link) {
 
 /***/ }),
 
-/***/ 36:
+/***/ 4115:
 /***/ ((module) => {
 
 module.exports = class HttpError extends Error {
@@ -24186,10 +24186,10 @@ module.exports = class HttpError extends Error {
 
 /***/ }),
 
-/***/ 5303:
+/***/ 6686:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(8526)
+var wrappy = __nccwpck_require__(7391)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -24235,14 +24235,14 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 746:
+/***/ 3069:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const os = __nccwpck_require__(2037);
-const macosRelease = __nccwpck_require__(3443);
-const winRelease = __nccwpck_require__(7554);
+const macosRelease = __nccwpck_require__(3701);
+const winRelease = __nccwpck_require__(4422);
 
 const osName = (platform, release) => {
 	if (!platform && release) {
@@ -24289,7 +24289,7 @@ module.exports = osName;
 
 /***/ }),
 
-/***/ 5935:
+/***/ 6397:
 /***/ ((module) => {
 
 "use strict";
@@ -24312,7 +24312,7 @@ module.exports = (promise, onFinally) => {
 
 /***/ }),
 
-/***/ 5932:
+/***/ 1507:
 /***/ ((module) => {
 
 "use strict";
@@ -24333,11 +24333,11 @@ module.exports = opts => {
 
 /***/ }),
 
-/***/ 886:
+/***/ 3509:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var once = __nccwpck_require__(5303)
-var eos = __nccwpck_require__(8246)
+var once = __nccwpck_require__(6686)
+var eos = __nccwpck_require__(228)
 var fs = __nccwpck_require__(7147) // we only need fs to get the ReadStream and WriteStream prototypes
 
 var noop = function () {}
@@ -24422,7 +24422,7 @@ module.exports = pump
 
 /***/ }),
 
-/***/ 4338:
+/***/ 2713:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -25912,12 +25912,12 @@ function coerce (version) {
 
 /***/ }),
 
-/***/ 5870:
+/***/ 8349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-var shebangRegex = __nccwpck_require__(3949);
+var shebangRegex = __nccwpck_require__(3370);
 
 module.exports = function (str) {
 	var match = str.match(shebangRegex);
@@ -25939,7 +25939,7 @@ module.exports = function (str) {
 
 /***/ }),
 
-/***/ 3949:
+/***/ 3370:
 /***/ ((module) => {
 
 "use strict";
@@ -25949,7 +25949,7 @@ module.exports = /^#!.*/;
 
 /***/ }),
 
-/***/ 6456:
+/***/ 4251:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Note: since nyc uses this module to output coverage, any lines
@@ -25978,7 +25978,7 @@ if (!processOk(process)) {
   }
 } else {
   var assert = __nccwpck_require__(9491)
-  var signals = __nccwpck_require__(4650)
+  var signals = __nccwpck_require__(3742)
   var isWin = /^win/i.test(process.platform)
 
   var EE = __nccwpck_require__(2361)
@@ -26158,7 +26158,7 @@ if (!processOk(process)) {
 
 /***/ }),
 
-/***/ 4650:
+/***/ 3742:
 /***/ ((module) => {
 
 // This is not the set of all possible signals.
@@ -26218,7 +26218,7 @@ if (process.platform === 'linux') {
 
 /***/ }),
 
-/***/ 8464:
+/***/ 5292:
 /***/ ((module) => {
 
 "use strict";
@@ -26241,7 +26241,7 @@ module.exports = function (x) {
 
 /***/ }),
 
-/***/ 4101:
+/***/ 5681:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26442,15 +26442,15 @@ module.exports.PROCESSING_OPTIONS = PROCESSING_OPTIONS;
 
 /***/ }),
 
-/***/ 2192:
+/***/ 538:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(3906);
+module.exports = __nccwpck_require__(8033);
 
 
 /***/ }),
 
-/***/ 3906:
+/***/ 8033:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26722,7 +26722,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 7505:
+/***/ 4667:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -26748,7 +26748,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 4382:
+/***/ 9349:
 /***/ ((module) => {
 
 "use strict";
@@ -26945,12 +26945,12 @@ conversions["RegExp"] = function (V, opts) {
 
 /***/ }),
 
-/***/ 2190:
+/***/ 4803:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-const usm = __nccwpck_require__(6301);
+const usm = __nccwpck_require__(2143);
 
 exports.implementation = class URLImpl {
   constructor(constructorArgs) {
@@ -27153,15 +27153,15 @@ exports.implementation = class URLImpl {
 
 /***/ }),
 
-/***/ 216:
+/***/ 3495:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const conversions = __nccwpck_require__(4382);
-const utils = __nccwpck_require__(864);
-const Impl = __nccwpck_require__(2190);
+const conversions = __nccwpck_require__(9349);
+const utils = __nccwpck_require__(4246);
+const Impl = __nccwpck_require__(4803);
 
 const impl = utils.implSymbol;
 
@@ -27357,32 +27357,32 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3821:
+/***/ 9941:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-exports.URL = __nccwpck_require__(216)["interface"];
-exports.serializeURL = __nccwpck_require__(6301).serializeURL;
-exports.serializeURLOrigin = __nccwpck_require__(6301).serializeURLOrigin;
-exports.basicURLParse = __nccwpck_require__(6301).basicURLParse;
-exports.setTheUsername = __nccwpck_require__(6301).setTheUsername;
-exports.setThePassword = __nccwpck_require__(6301).setThePassword;
-exports.serializeHost = __nccwpck_require__(6301).serializeHost;
-exports.serializeInteger = __nccwpck_require__(6301).serializeInteger;
-exports.parseURL = __nccwpck_require__(6301).parseURL;
+exports.URL = __nccwpck_require__(3495)["interface"];
+exports.serializeURL = __nccwpck_require__(2143).serializeURL;
+exports.serializeURLOrigin = __nccwpck_require__(2143).serializeURLOrigin;
+exports.basicURLParse = __nccwpck_require__(2143).basicURLParse;
+exports.setTheUsername = __nccwpck_require__(2143).setTheUsername;
+exports.setThePassword = __nccwpck_require__(2143).setThePassword;
+exports.serializeHost = __nccwpck_require__(2143).serializeHost;
+exports.serializeInteger = __nccwpck_require__(2143).serializeInteger;
+exports.parseURL = __nccwpck_require__(2143).parseURL;
 
 
 /***/ }),
 
-/***/ 6301:
+/***/ 2143:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const punycode = __nccwpck_require__(5477);
-const tr46 = __nccwpck_require__(4101);
+const tr46 = __nccwpck_require__(5681);
 
 const specialSchemes = {
   ftp: 21,
@@ -28681,7 +28681,7 @@ module.exports.parseURL = function (input, options) {
 
 /***/ }),
 
-/***/ 864:
+/***/ 4246:
 /***/ ((module) => {
 
 "use strict";
@@ -28709,7 +28709,7 @@ module.exports.implForWrapper = function (wrapper) {
 
 /***/ }),
 
-/***/ 8742:
+/***/ 2532:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = which
@@ -28721,7 +28721,7 @@ var isWindows = process.platform === 'win32' ||
 
 var path = __nccwpck_require__(1017)
 var COLON = isWindows ? ';' : ':'
-var isexe = __nccwpck_require__(769)
+var isexe = __nccwpck_require__(2949)
 
 function getNotFoundError (cmd) {
   var er = new Error('not found: ' + cmd)
@@ -28851,13 +28851,13 @@ function whichSync (cmd, opt) {
 
 /***/ }),
 
-/***/ 7554:
+/***/ 4422:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const os = __nccwpck_require__(2037);
-const execa = __nccwpck_require__(5883);
+const execa = __nccwpck_require__(8300);
 
 // Reference: https://www.gaijin.at/en/lstwinver.php
 const names = new Map([
@@ -28911,7 +28911,7 @@ module.exports = windowsRelease;
 
 /***/ }),
 
-/***/ 8526:
+/***/ 7391:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -28951,7 +28951,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 7106:
+/***/ 4765:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -29079,15 +29079,15 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 3350:
+/***/ 6360:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(9640);
-var resolveSeq = __nccwpck_require__(8866);
-var Schema = __nccwpck_require__(6396);
+var PlainValue = __nccwpck_require__(3009);
+var resolveSeq = __nccwpck_require__(4440);
+var Schema = __nccwpck_require__(6467);
 
 const defaultOptions = {
   anchorPrefix: 'a',
@@ -29844,7 +29844,7 @@ exports.scalarOptions = scalarOptions;
 
 /***/ }),
 
-/***/ 9640:
+/***/ 3009:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -30728,15 +30728,15 @@ exports.defaultTags = defaultTags;
 
 /***/ }),
 
-/***/ 6396:
+/***/ 6467:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(9640);
-var resolveSeq = __nccwpck_require__(8866);
-var warnings = __nccwpck_require__(5487);
+var PlainValue = __nccwpck_require__(3009);
+var resolveSeq = __nccwpck_require__(4440);
+var warnings = __nccwpck_require__(9670);
 
 function createMap(schema, obj, ctx) {
   const map = new resolveSeq.YAMLMap(schema);
@@ -31261,18 +31261,18 @@ exports.Schema = Schema;
 
 /***/ }),
 
-/***/ 5394:
+/***/ 3932:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var parseCst = __nccwpck_require__(1197);
-var Document$1 = __nccwpck_require__(3350);
-var Schema = __nccwpck_require__(6396);
-var PlainValue = __nccwpck_require__(9640);
-var warnings = __nccwpck_require__(5487);
-__nccwpck_require__(8866);
+var parseCst = __nccwpck_require__(5053);
+var Document$1 = __nccwpck_require__(6360);
+var Schema = __nccwpck_require__(6467);
+var PlainValue = __nccwpck_require__(3009);
+var warnings = __nccwpck_require__(9670);
+__nccwpck_require__(4440);
 
 function createNode(value, wrapScalars = true, tag) {
   if (tag === undefined && typeof wrapScalars === 'string') {
@@ -31348,13 +31348,13 @@ exports.YAML = YAML;
 
 /***/ }),
 
-/***/ 1197:
+/***/ 5053:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(9640);
+var PlainValue = __nccwpck_require__(3009);
 
 class BlankLine extends PlainValue.Node {
   constructor() {
@@ -33109,13 +33109,13 @@ exports.parse = parse;
 
 /***/ }),
 
-/***/ 8866:
+/***/ 4440:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(9640);
+var PlainValue = __nccwpck_require__(3009);
 
 function addCommentBefore(str, indent, comment) {
   if (!comment) return str;
@@ -35278,14 +35278,14 @@ exports.toJSON = toJSON;
 
 /***/ }),
 
-/***/ 5487:
+/***/ 9670:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(9640);
-var resolveSeq = __nccwpck_require__(8866);
+var PlainValue = __nccwpck_require__(3009);
+var resolveSeq = __nccwpck_require__(4440);
 
 /* global atob, btoa, Buffer */
 const binary = {
@@ -35702,10 +35702,10 @@ exports.warnOptionDeprecation = warnOptionDeprecation;
 
 /***/ }),
 
-/***/ 3514:
+/***/ 8912:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(5394).YAML
+module.exports = __nccwpck_require__(3932).YAML
 
 
 /***/ }),
@@ -35714,7 +35714,7 @@ module.exports = __nccwpck_require__(5394).YAML
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@octokit/rest","version":"16.43.2","publishConfig":{"access":"public"},"description":"GitHub REST API client for Node.js","keywords":["octokit","github","rest","api-client"],"author":"Gregor Martynus (https://github.com/gr2m)","contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"repository":"https://github.com/octokit/rest.js","dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^4.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^6.0.0","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"types":"index.d.ts","scripts":{"coverage":"nyc report --reporter=html && open coverage/index.html","lint":"prettier --check \'{lib,plugins,scripts,test}/**/*.{js,json,ts}\' \'docs/*.{js,json}\' \'docs/src/**/*\' index.js README.md package.json","lint:fix":"prettier --write \'{lib,plugins,scripts,test}/**/*.{js,json,ts}\' \'docs/*.{js,json}\' \'docs/src/**/*\' index.js README.md package.json","pretest":"npm run -s lint","test":"nyc mocha test/mocha-node-setup.js \\"test/*/**/*-test.js\\"","test:browser":"cypress run --browser chrome","build":"npm-run-all build:*","build:ts":"npm run -s update-endpoints:typescript","prebuild:browser":"mkdirp dist/","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","prevalidate:ts":"npm run -s build:ts","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","start-fixtures-server":"octokit-fixtures-server"},"license":"MIT","files":["index.js","index.d.ts","lib","plugins"],"nyc":{"ignore":["test"]},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}]}');
+module.exports = JSON.parse('{"_args":[["@octokit/rest@16.43.2","/Users/robandpdx/github/issue-body-parser-action"]],"_from":"@octokit/rest@16.43.2","_id":"@octokit/rest@16.43.2","_inBundle":false,"_integrity":"sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==","_location":"/@octokit/rest","_phantomChildren":{"@types/node":"17.0.41","deprecation":"2.3.1","once":"1.4.0","os-name":"3.1.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.2","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.2","saveSpec":null,"fetchSpec":"16.43.2"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz","_spec":"16.43.2","_where":"/Users/robandpdx/github/issue-body-parser-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^4.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^6.0.0","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check \'{lib,plugins,scripts,test}/**/*.{js,json,ts}\' \'docs/*.{js,json}\' \'docs/src/**/*\' index.js README.md package.json","lint:fix":"prettier --write \'{lib,plugins,scripts,test}/**/*.{js,json,ts}\' \'docs/*.{js,json}\' \'docs/src/**/*\' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \\"test/*/**/*-test.js\\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.2"}');
 
 /***/ }),
 
@@ -35767,9 +35767,9 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const core = __nccwpck_require__(2896),
-  github = __nccwpck_require__(1539),
-  YAML = __nccwpck_require__(3514);
+const core = __nccwpck_require__(2362),
+  github = __nccwpck_require__(5903),
+  YAML = __nccwpck_require__(8912);
 
 // A singleton Octokit for using to access the GitHub API
 let octokit = null;
@@ -35777,6 +35777,7 @@ let octokit = null;
 
 async function run() {
   const issueId = getRequiredInputValue('issue_id');
+  const failOnMissing = core.getBooleanInput('fail_on_missing');
 
   try {
     const issueBody = await getIssueBody(issueId),
@@ -35785,7 +35786,14 @@ async function run() {
     if (result !== null) {
       core.setOutput('payload', result);
     } else {
-      core.setFailed(`There was no valid payload found in the issue: ${issueId}.`);
+      if (!failOnMissing) {
+        core.warning(`There was no valid payload found in the issue: ${issueId}.`);
+        core.setOutput('payload', "NOT_FOUND");
+      } else {
+        core.warning(`failOnMissing: ${failOnMissing}.`);
+        core.setFailed(`There was no valid payload found in the issue: ${issueId}.`);
+      }
+      
     }
   } catch (err) {
     core.setFailed(err);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ let octokit = null;
 
 async function run() {
   const issueId = getRequiredInputValue('issue_id');
+  const failOnMissing = core.getBooleanInput('fail_on_missing');
 
   try {
     const issueBody = await getIssueBody(issueId),
@@ -16,7 +17,14 @@ async function run() {
     if (result !== null) {
       core.setOutput('payload', result);
     } else {
-      core.setFailed(`There was no valid payload found in the issue: ${issueId}.`);
+      if (!failOnMissing) {
+        core.warning(`There was no valid payload found in the issue: ${issueId}.`);
+        core.setOutput('payload', "NOT_FOUND");
+      } else {
+        core.warning(`failOnMissing: ${failOnMissing}.`);
+        core.setFailed(`There was no valid payload found in the issue: ${issueId}.`);
+      }
+      
     }
   } catch (err) {
     core.setFailed(err);


### PR DESCRIPTION
This change adds the `fail_on_missing` option, #6. The default is `true` so that current behavior stays the same. When set to `false` and the payload is not found, the action does not fail and the payload value is set to `NOT_FOUND`. This value is useful so you can configure downstream workflow actions to test this value and skip if desired.

For example, using the following workflow:
```yaml
name: Test issue-body-parser-action

on:
  issues:
    types: [opened]

jobs:
  test-non-failure:
    runs-on: ubuntu-latest
    steps:
    - name: Get JSON Data out of Issue Request
      uses: robandpdx/issue-body-parser-action@option-to-not-fail
      id: issue_body_parser_request
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
        issue_id: ${{ github.event.issue.number }}
        payload_marker: request
        fail_on_missing: false
    - name: Run something
      if : steps.issue_body_parser_request.outputs.payload != 'NOT_FOUND'
      id: run_something
      run: |
        echo ${{ fromJson(steps.issue_body_parser_request.outputs.payload).version }}
```

... we get the following output when the payload is not found...
![Screen Shot 2022-09-01 at 10 32 49 PM](https://user-images.githubusercontent.com/95243761/188065945-e35d4c25-832a-4cb9-9a09-28b567708c40.png)

As you can see from the output above, the step using this action did not fail, and the `Run something` step was skipped by using the `if` conditional to test the value of the payload.

I have added the following section to the readme to explain this...
![Screen Shot 2022-09-07 at 7 21 57 PM](https://user-images.githubusercontent.com/95243761/189019330-e2c08bf8-af4e-40e2-aad7-3cbbd478d107.png)

